### PR TITLE
Use SESSION_SECRET env and document

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+DB_NAME=your_database_name
+DB_USER=your_database_username
+DB_PASSWORD=your_database_password
+SESSION_SECRET=your_session_secret

--- a/Readme.md
+++ b/Readme.md
@@ -50,12 +50,13 @@ Before you begin, ensure you have met the following requirements:
    ```
 4. Create a .env file in the root directory of the project.
 5. Add the following environment variables to the .env file:
-    ```plaintext
+   ```plaintext
    DB_NAME=your_database_name
-    DB_USER=your_database_username
-    DB_PASSWORD=your_database_password
+   DB_USER=your_database_username
+   DB_PASSWORD=your_database_password
+   SESSION_SECRET=your_session_secret
    ```
-    Replace your_database_name, your_database_username, and your_database_password with your actual database credentials.
+   Replace your_database_name, your_database_username, and your_database_password with your actual database credentials.
 
 6. To start the application, run the following command:
     ```bash

--- a/server.js
+++ b/server.js
@@ -15,8 +15,11 @@ const PORT = process.env.PORT || 3001;
 // Set up Handlebars.js engine with custom helpers
 const hbs = exphbs.create({ helpers });
 
+// Use SESSION_SECRET from environment or fall back to a placeholder
+const sessionSecret = process.env.SESSION_SECRET || 'Super secret secret';
+
 const sess = {
-	secret: 'Super secret secret',
+        secret: sessionSecret,
 	cookie: {
 		maxAge: 300000,
 		httpOnly: true,


### PR DESCRIPTION
## Summary
- read SESSION_SECRET from environment with fallback
- explain SESSION_SECRET in README
- provide `.env.example` with all required variables

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c88b1c7f483278ba17d6bcc819cfb