### PR TITLE
Add user profile page

### DIFF
--- a/controllers/homeRoutes.js
+++ b/controllers/homeRoutes.js
@@ -107,6 +107,36 @@ router.post('/signup', async (req, res) => {
 	}
 });
 
+// Route to display a user's profile by id
+router.get('/profile/:id', async (req, res) => {
+        try {
+                const userData = await User.findByPk(req.params.id, {
+                        include: [
+                                {
+                                        model: Tweet,
+                                        attributes: ['content', 'createdAt'],
+                                },
+                        ],
+                });
+
+                if (!userData) {
+                        return res.status(404).send('User not found');
+                }
+
+                const profile = userData.get({ plain: true });
+
+                res.render('profile', {
+                        user: req.session.user,
+                        profile,
+                        tweets: profile.tweets,
+                        logged_in: !!req.session.user,
+                });
+        } catch (err) {
+                console.error('Failed to load profile:', err);
+                res.status(500).send('Error loading profile');
+        }
+});
+
 // Route to handle user logout
 // Assuming this is inside your router setup file, such as authRoutes.js
 router.post('/logout', (req, res) => {

--- a/views/homepage.handlebars
+++ b/views/homepage.handlebars
@@ -13,7 +13,7 @@
                 <span class="icon">📝</span>
                 <span>Lists</span>
             </a>
-            <a class="w-full bg-green-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded flex justify-center items-center">
+            <a href="/profile/{{user.id}}" class="w-full bg-green-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded flex justify-center items-center">
                 <span class="icon">👤</span>
                 <span>Profile</span>
             </a>

--- a/views/profile.handlebars
+++ b/views/profile.handlebars
@@ -1,0 +1,11 @@
+<div class="p-6 space-y-6 font-mono">
+    <h2 class="text-2xl font-bold mb-4">{{profile.username}}'s Profile</h2>
+    <div class="space-y-4">
+        {{#each profile.tweets}}
+        <div class="card bg-white shadow rounded-lg p-4">
+            <p class="text-gray-800">{{this.content}}</p>
+            <p class="text-sm text-gray-600">Posted on {{format_date this.createdAt}}</p>
+        </div>
+        {{/each}}
+    </div>
+</div>


### PR DESCRIPTION
## Summary
- create `/profile/:id` route that fetches a user and their tweets
- render new `profile.handlebars` for that route
- link to the profile page from the homepage sidebar

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c88a79d408327a4e3f3fee0bc9447