### PR TITLE
Implement ephemeral tweet deletion

### DIFF
--- a/controllers/tweets.js
+++ b/controllers/tweets.js
@@ -27,4 +27,21 @@ router.post('/', async (req, res) => {
 	}
 });
 
+// Delete a tweet by id
+router.delete('/:id', async (req, res) => {
+        try {
+                const tweetId = req.params.id;
+
+                const deleted = await Tweet.destroy({ where: { id: tweetId } });
+                if (!deleted) {
+                        return res.status(404).json({ message: 'Tweet not found' });
+                }
+
+                res.json({ message: 'Tweet deleted' });
+        } catch (error) {
+                console.error(error);
+                res.status(500).json({ message: 'Failed to delete tweet' });
+        }
+});
+
 module.exports = router;

--- a/models/Tweet.js
+++ b/models/Tweet.js
@@ -17,15 +17,22 @@ Tweet.init(
 			type: DataTypes.TEXT,
 			allowNull: true,
 		},
-		user_id: {
-			type: DataTypes.INTEGER,
-			allowNull: false,
-			references: {
-				model: 'user', // This references the 'users' table
-				key: 'id',
-			},
-		},
-	},
+                user_id: {
+                        type: DataTypes.INTEGER,
+                        allowNull: false,
+                        references: {
+                                model: 'user', // This references the 'users' table
+                                key: 'id',
+                        },
+                },
+                // Indicates whether a tweet should be automatically removed
+                // once it's out of view on the client
+                ephemeral: {
+                        type: DataTypes.BOOLEAN,
+                        allowNull: false,
+                        defaultValue: false,
+                },
+        },
 	{
 		sequelize,
 		modelName: 'tweet',

--- a/public/js/tweet.js
+++ b/public/js/tweet.js
@@ -2,6 +2,28 @@ document.addEventListener('DOMContentLoaded', () => {
     const tweetButton = document.getElementById('tweetSubmit');
     const tweetInput = document.getElementById('tweetInput');
     const tweetsContainer = document.getElementById('tweetsContainer');
+
+    const observer = new IntersectionObserver((entries) => {
+        entries.forEach(async (entry) => {
+            if (!entry.isIntersecting) {
+                const el = entry.target;
+                const id = el.dataset.tweetId;
+                if (id) {
+                    try {
+                        const response = await fetch(`/tweets/${id}`, { method: 'DELETE' });
+                        if (response.ok) {
+                            el.remove();
+                        }
+                    } catch (err) {
+                        console.error('Failed to delete tweet', err);
+                    }
+                }
+                observer.unobserve(el);
+            }
+        });
+    }, { threshold: 0 });
+
+    document.querySelectorAll('[data-tweet-id]').forEach(el => observer.observe(el));
     
     tweetButton.addEventListener('click', async () => {
         const tweetContent = tweetInput.value.trim();
@@ -18,12 +40,14 @@ document.addEventListener('DOMContentLoaded', () => {
                     // Append the new tweet to the tweetsContainer
                     const newTweetDiv = document.createElement('div');
                     newTweetDiv.className = 'card bg-white shadow rounded-lg p-6 mb-4';
+                    newTweetDiv.dataset.tweetId = data.tweet ? data.tweet.id : '';
                     newTweetDiv.innerHTML = `
                         <div class="flex flex-col">
                             <p class="text-gray-800">${data.tweet ? data.tweet.content : 'Error: Tweet content missing.'}</p>
                             <p class="text-sm text-gray-600">Posted just now</p>
                         </div>`;
                     tweetsContainer.prepend(newTweetDiv); // Add the new tweet at the top
+                    observer.observe(newTweetDiv);
                     tweetInput.value = ''; // Clear the textarea
                 } else {
                     throw new Error(data.message || 'Failed to post tweet');

--- a/seeds/tweetData.json
+++ b/seeds/tweetData.json
@@ -2,11 +2,13 @@
     {
         "content": "Exploring the world of Node.js!",
         "user_id": 1,
-        "created_at": "2024-04-12T12:00:00Z"
+        "created_at": "2024-04-12T12:00:00Z",
+        "ephemeral": false
     },
     {
         "content": "Just attended an amazing JavaScript conference!",
         "user_id": 2,
-        "created_at": "2024-04-13T15:30:00Z"
+        "created_at": "2024-04-13T15:30:00Z",
+        "ephemeral": false
     }
 ]

--- a/views/homepage.handlebars
+++ b/views/homepage.handlebars
@@ -35,7 +35,7 @@
         <!-- Cards from all users -->
         <div id="tweetsContainer" class="space-y-4">
             {{#each tweets}}
-            <div class="card bg-white shadow rounded-lg p-6 mb-4">
+            <div class="card bg-white shadow rounded-lg p-6 mb-4" data-tweet-id="{{this.id}}">
                 <div class="flex flex-col">
                     <p class="text-gray-800">{{this.content}}</p>
                     <p class="text-sm text-gray-600">Posted on {{format_date createdAt}}</p>


### PR DESCRIPTION
## Summary
- add `ephemeral` flag to Tweet model and seed data
- provide DELETE `/tweets/:id` API endpoint
- mark tweet cards with their id and observe them leaving the viewport
- automatically DELETE the tweet and remove it from the DOM when it goes off screen

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c88a22a7c8327a4d2127e11521ac0