### PR TITLE
Implement profile and 404 features

### DIFF
--- a/controllers/index.js
+++ b/controllers/index.js
@@ -10,4 +10,12 @@ router.use('/tweets', tweetsRoutes); // Make sure this is pointing to a router
 // router.use('/likes', likesController);
 // router.use('/auth', authController);
 
+// Catch-all handler for any routes that don't exist
+router.use('*', (req, res) => {
+  res.status(404).render('404', {
+    user: req.session.user,
+    logged_in: !!req.session.user,
+  });
+});
+
 module.exports = router;

--- a/views/404.handlebars
+++ b/views/404.handlebars
@@ -1,0 +1,9 @@
+<div class="flex flex-col items-center justify-center h-full p-10 font-mono">
+    <h2 class="text-3xl font-bold mb-4">404 - Page Not Found</h2>
+    <p class="mb-4">Sorry, we couldn't find that page.</p>
+    {{#if logged_in}}
+    <a href="/homepage" class="text-blue-500 hover:underline">Return to Home</a>
+    {{else}}
+    <a href="/login" class="text-blue-500 hover:underline">Go to Login</a>
+    {{/if}}
+</div>


### PR DESCRIPTION
## Summary
- add catch-all route to render 404 page
- create a simple 404 view

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684c8aeeeff48327a54042c11bb736e9