### PR TITLE
Read SESSION_SECRET from env

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,4 +1,5 @@
 DB_NAME=your_database_name
 DB_USER=your_database_username
 DB_PASSWORD=your_database_password
+# Secret string used for signing session cookies
 SESSION_SECRET=your_session_secret

--- a/server.js
+++ b/server.js
@@ -15,11 +15,9 @@ const PORT = process.env.PORT || 3001;
 // Set up Handlebars.js engine with custom helpers
 const hbs = exphbs.create({ helpers });
 
-// Use SESSION_SECRET from environment or fall back to a placeholder
-const sessionSecret = process.env.SESSION_SECRET || 'Super secret secret';
-
+// Use SESSION_SECRET from environment
 const sess = {
-        secret: sessionSecret,
+        secret: process.env.SESSION_SECRET,
 	cookie: {
 		maxAge: 300000,
 		httpOnly: true,


### PR DESCRIPTION
## Summary
- use `process.env.SESSION_SECRET` directly for express-session
- clarify `SESSION_SECRET` usage in `.env.example`

## Testing
- `npm test` *(fails: "Error: no test specified")*

------
https://chatgpt.com/codex/tasks/task_e_684c8b2d98848327901964954b71ffa1